### PR TITLE
Link to the 2019 events on our new Meetup

### DIFF
--- a/events/2019/1-nodeschool.md
+++ b/events/2019/1-nodeschool.md
@@ -4,7 +4,7 @@ date: 2019-07-13
 actions:
   -
     title: Sign up for Nodeschool
-    url: http://www.meetup.com/JSOxford/events/231241282/
+    url: https://www.meetup.com/Summer-Of-Hacks-Oxford/events/258794540/
 ---
 
 NodeSchool is a collection of workshops that help you learn JavaScript by writing code and solving challenges. The event is for everyone, whether you've never written a line of JavaScript before or you're a pro; NodeSchool has challenges and activities for all different levels.

--- a/events/2019/2-hardware.md
+++ b/events/2019/2-hardware.md
@@ -4,11 +4,19 @@ date: 2019-08-17
 actions:
   -
     title: Sign up for Hardware
-    url: http://www.meetup.com/JSOxford/events/231241496/
+    url: https://www.meetup.com/Summer-Of-Hacks-Oxford/events/258795349/
 ---
 
-This is a day of hacking on hardware. It's for anyone who is interested in learning about hardware and there is no minimum entry requirememts, other than an equisitive mind.
+This is a day of hacking on hardware. It's for anyone who is interested in
+learning about hardware. There are no minimum entry requirements other than an
+inquisitive mind.
 
-If you've never touched a breadboard before, that's fine – We’re bringing some starter packs, complete with Espruino boards and components and plenty of helpful people to guide you. If you're a bit more experienced that's great too, as you'll get to play with some new kit or hack on a project with like-minded people.
+If you've never touched a breadboard before, that's fine: we’re bringing some
+starter packs, complete with Espruino boards and components and plenty of
+helpful people to guide you. If you're a bit more experienced that's great too,
+as you'll get to play with some new kit or hack on a project with like-minded people.
 
-You'll probably want to being a laptop (and it's charger) and you're welcome to bring any other tools and components you have. We'd recommend marking them up somehow so it's easy to check you're taking the right things home.
+You'll probably want to bring a laptop _and its charger_. You're also welcome to
+bring any other tools and components you have. We recommend marking them up
+somehow—using washi tape, stickers, etc.—so it's easy to check you're taking the
+right things home.

--- a/events/2019/3-language-hackday.md
+++ b/events/2019/3-language-hackday.md
@@ -4,7 +4,7 @@ date: 2019-09-14
 actions:
   -
     title: Sign up for Language Hackday
-    url: http://www.meetup.com/JSOxford/events/231241391/
+    url: https://www.meetup.com/Summer-Of-Hacks-Oxford/events/258795370/
 ---
 
 The Language Hackday is a day-long event primarily geared towards making machines do things with human language, either in text or audio form. It is for anyone interested in using computers to analyse, create, transform, or otherwise play with any of the 6,000 human languages (though the major world languages will be easier to find data on).


### PR DESCRIPTION
We were linking to Meetup events from SOH in the past.

We now have a shiny Meetup account of our very own so I've linked each event on the website to the actual event on Meetup.

> The events [are still drafts](https://www.meetup.com/Summer-Of-Hacks-Oxford/events/drafts/) but that's cool for now.