### PR TITLE
add code of conduct to website page

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -129,9 +129,30 @@
 
       <h1>Code of Conduct</h1>
 
-      <p><strong>All</strong> of our events follow a code of conduct that you can read at
-        <a href="https://github.com/summer-of-hacks/soh19website/blob/master/CODEOFCONDUCT.md">
-          https://github.com/summer-of-hacks/soh19website/blob/master/CODEOFCONDUCT.md</a></p>
+      <p><strong>All</strong> of our events follow a code of conduct and are dedicated to providing a harassment-free event experience for everyone, regardless of gender, age, sexual orientation, disability, physical appearance, body size, race, or religion (or lack thereof). We do not tolerate harassment of event participants in any form. Sexual language and imagery is not appropriate for any event venue. Event participants violating these rules may be sanctioned or expelled from the event at the discretion of the event organisers.</p>
+
+<p>tl;dr: Be excellent with each other</p>
+
+<h2>Need Help?</h2>
+<p>The Summer of Hacks organisers are there to help you have a good time. If you have any questions, concerns or need help, please reach out to us:</p>
+
+<p>Adam Leskis, leskis@gmail.com (slack - @aleskis)</p>
+<p>Rich Douglas, rich.douglas.evans@gmail.com (slack - @rich)</p>
+
+<h2>The Less Quick Version</h2>
+<p>Harassment includes offensive verbal comments related to gender, age, sexual orientation, disability, physical appearance, body size, race, religion, sexual images in public spaces, deliberate intimidation, stalking, following, harassing photography or recording, sustained disruption of talks or other events, inappropriate physical contact, and unwelcome sexual attention.</p>
+
+<p>Participants asked to stop any harassing behaviour are expected to comply immediately.</p>
+
+<p>Sponsors and speakers are also subject to the anti-harassment policy. In particular, sponsors should not use sexualised images, activities, or other material. Sponsors, speakers and event staff (including volunteers) should not use sexualised clothing/uniforms/costumes, or otherwise create a sexualised environment.</p>
+
+<p>If a participant engages in harassing behaviour, the event organisers may take any action they deem appropriate, including warning the offender or expulsion from the event with no refund (if applicable).</p>
+
+<p>If you are being harassed, notice that someone else is being harassed, or have any other concerns, please contact a member of event staff immediately.</p>
+
+<p>Event staff will be happy to help participants contact venue security or the police, provide escorts, or otherwise assist those experiencing harassment to feel safe for the duration of the event. We value your attendance.</p>
+
+<p>We expect participants to follow these rules at event venues and related social events.</p>
 
       <p>It's our absolute priority that attendees are safe and feel respected.
         If you have any issues, concerns, or questions then contact us:


### PR DESCRIPTION
Putting this on the main page, so we don't need to use an external github link.