### PR TITLE
 Spilt IndieWebCamp word 

### DIFF
--- a/events/2019/4-indiewebcamp.md
+++ b/events/2019/4-indiewebcamp.md
@@ -1,5 +1,5 @@
 ---
-name: IndieWeb<wbr>Camp
+name: IndieWeb Camp
 date: 2019-09-28
 actions:
   -

--- a/events/2019/4-indiewebcamp.md
+++ b/events/2019/4-indiewebcamp.md
@@ -1,14 +1,14 @@
 ---
-name: IndieWeb Camp
+name: Indie Web Camp
 date: 2019-09-28
 actions:
   -
-    title: Sign up for IndieWebCamp
+    title: Sign up for Indie Web Camp
     url: https://www.meetup.com/Summer-Of-Hacks-Oxford/events/261075078/
 ---
 
-IndieWebCamp is a one-day gathering of web creators building & sharing their own websites to advance the independent web and empower ourselves and others to take control of our identities and data.
+Indie Web Camp is a one-day gathering of web creators building & sharing their own websites to advance the independent web and empower ourselves and others to take control of our identities and data.
 
 It is open to all skill levels, from people who want to get started with a web site, through to experienced developers wanting to tackle a specific personal project.
 
-IndieWebCamp is for independent web creators of all kinds, and all levels, from graphic artists, to designers, UX engineers, coders; to share ideas, actively work on creating for their own personal websites, and build upon each others creations.
+Indie Web Camp is for independent web creators of all kinds, and all levels, from graphic artists, to designers, UX engineers, coders; to share ideas, actively work on creating for their own personal websites, and build upon each others creations.

--- a/events/2019/4-indiewebcamp.md
+++ b/events/2019/4-indiewebcamp.md
@@ -1,5 +1,5 @@
 ---
-name: IndieWebCamp
+name: IndieWeb<wbr>Camp
 date: 2019-09-28
 actions:
   -


### PR DESCRIPTION
A quick fix in lieu of a way around the markdown library removing html.